### PR TITLE
common/camera: Add meson definitions to build HAL hwmodule

### DIFF
--- a/common/camera/board.mk
+++ b/common/camera/board.mk
@@ -9,6 +9,8 @@ BCC_PATH := $(patsubst $(CURDIR)/%,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)
 BOARD_BUILD_AOSPEXT_LIBCAMERA := true
 BOARD_LIBCAMERA_SRC_DIR := glodroid/vendor/libcamera
 BOARD_LIBCAMERA_PIPELINES ?= simple
+BOARD_LIBCAMERA_EXTRA_MESON_ARGS := -Dandroid=enabled
+BOARD_LIBCAMERA_EXTRA_TARGETS := lib:libcamera-hal.so:hw:camera.libcamera:
 
 DEVICE_MANIFEST_FILE += $(BCC_PATH)/android.hardware.camera.provider@2.5.xml
 


### PR DESCRIPTION
This is required after [1] commit

[1]: https://github.com/GloDroid/aospext/commit/7f85fd53d7a90239135b27e96643996e31744233
Signed-off-by: Roman Stratiienko <r.stratiienko@gmail.com>