### PR TITLE
Fix app.te while building dist

### DIFF
--- a/common/graphics/sepolicy/vendor/app.te
+++ b/common/graphics/sepolicy/vendor/app.te
@@ -1,4 +1,4 @@
 # Few system/untrusted_app_xx apps eg. deskclock,
 # gallery3d et al. need read-only access to /dev/dri
 # as well, otherwise they don't open and crash.
-gpu_access(appdomain -isolated_app)
+gpu_access(appdomain -isolated_app_all)


### PR DESCRIPTION
make dist failed with error:

FAILED: build out/target/product/rpi4_car/obj/FAKE/treble_sepolicy_tests_33.0_intermediates/treble_sepolicy_tests_33.0 Outputs: out/target/product/rpi4_car/obj/FAKE/treble_sepolicy_tests_33.0_intermediates/treble_sepolicy_tests_33.0 Error: exited with code: 1
Command: /bin/bash -c "(out/host/linux-x86/bin/treble_sepolicy_tests  -f out/target/product/rpi4_car/system/etc/selinux/plat_file_contexts  -f out/target/product/rpi4_car/vendor/etc/selinux/vendor_file_contexts  -f out/target/product/rpi4_car/product/etc/selinux/product_file_contexts                 -b out/target/product/rpi4_car/obj/ETC/base_plat_sepolicy_intermediates/base_plat_sepolicy -m out/target/product/rpi4_car/obj/FAKE/treble_sepolicy_tests_33.0_intermediates/33.0_mapping.combined.cil                 -o out/target/product/rpi4_car/obj/FAKE/treble_sepolicy_tests_33.0_intermediates/built_33.0_plat_sepolicy -p out/target/product/rpi4_car/obj/ETC/precompiled_sepolicy_intermediates/precompiled_sepolicy                 -u out/target/product/rpi4_car/obj/ETC/base_plat_pub_policy.cil_intermediates/base_plat_pub_policy.cil ) && (touch out/target/product/rpi4_car/obj/FAKE/treble_sepolicy_tests_33.0_intermediates/treble_sepolicy_tests_33.0 )"
Output:
Found prohibited permission granted for isolated like types. Please replace your allow statements that involve "-isolated_app" with "-isolated_app_all". Violations are shown as the following: 
allow isolated_compute_app sysfs_gpu:file read 
allow isolated_compute_app dri_device:dir search 
allow isolated_compute_app dri_device:dir read 
allow isolated_compute_app sysfs_gpu:dir search 
allow isolated_compute_app sysfs_gpu:file open 
allow isolated_compute_app dri_device:dir open 
allow isolated_compute_app sysfs_gpu:file getattr